### PR TITLE
Update TS eslint for optional chaining support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "test": "eslint --ext '.js,.ts,.tsx' tests/**"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.3.1",
-    "@typescript-eslint/parser": "^2.3.1",
+    "@typescript-eslint/eslint-plugin": "^2.12.0",
+    "@typescript-eslint/parser": "^2.12.0",
     "babel-eslint": "^10.0.3",
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-babel": "^5.3.0",


### PR DESCRIPTION
Optional chaining requires at least 2.7